### PR TITLE
Add shooter setpoint for shuttling pieces across the field

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -80,6 +80,9 @@ public class RobotContainer {
             .andThen(new ShootAmpCommand(shooter))
             .withName("ShootAmpCommand");
 
+    // Shooting to shuttle uses same logic as shooting in speaker
+    private Command shootShuttleCommand = shootSpeakerCommand;
+
     private OrchestraCommand startupOrchestraCommand = new OrchestraCommand(drive, this::getInput, "windows-xp.chrp");
 
     private Command backoffShooterCommand = new BackoffShooterCommand(shooter);
@@ -97,6 +100,7 @@ public class RobotContainer {
     private final Trigger runSysidTrigger;
     private final Trigger shootSpeakerTrigger;
     private final Trigger shootAmpTrigger;
+    private final Trigger shootShuttleTrigger;
     private final Trigger reZeroIntakeTrigger;
     private final Trigger reZeroClimbTrigger;
     private final Trigger handoffTrigger;
@@ -146,6 +150,7 @@ public class RobotContainer {
         runSysidTrigger = new Trigger(() -> getInput().getRunSysId());
         shootSpeakerTrigger = new Trigger(() -> getInput().getShootTargetDebounced() == MoInput.ShootTarget.SPEAKER);
         shootAmpTrigger = new Trigger(() -> getInput().getShootTargetDebounced() == MoInput.ShootTarget.AMP);
+        shootShuttleTrigger = new Trigger(() -> getInput().getShootTargetDebounced() == MoInput.ShootTarget.SHUTTLE);
         reZeroClimbTrigger = new Trigger(() -> !climb.bothZeroed());
         reZeroIntakeTrigger = new Trigger(() -> !intake.isDeployZeroed.getBoolean(false));
         handoffTrigger = new Trigger(() -> getInput().getHandoff());
@@ -167,11 +172,14 @@ public class RobotContainer {
         calibrateDriveButton.onTrue(new CalibrateSwerveDriveCommand(drive));
         calibrateTurnButton.whileTrue(new CalibrateSwerveTurnCommand(drive, this::getInput));
         coastSwerveButton.whileTrue(new CoastSwerveDriveCommand(drive));
-        burnFlashButton.onTrue(Commands.runOnce(() -> {shooter.burnFlash();}));
+        burnFlashButton.onTrue(Commands.runOnce(() -> {
+            shooter.burnFlash();
+        }));
 
         var tuneSetpointSubscriber = MoShuffleboard.getInstance().tuneSetpointSubscriber;
         shootSpeakerTrigger.whileTrue(shootSpeakerCommand);
         shootAmpTrigger.whileTrue(shootAmpCommand);
+        shootShuttleTrigger.whileTrue(shootShuttleCommand);
 
         reZeroIntakeTrigger.onTrue(reZeroIntake);
 

--- a/src/main/java/frc/robot/component/ArmSetpointManager.java
+++ b/src/main/java/frc/robot/component/ArmSetpointManager.java
@@ -14,7 +14,8 @@ public class ArmSetpointManager {
         HANDOFF,
         SPEAKER,
         AMP,
-        SOURCE
+        SOURCE,
+        SHUTTLE
     };
 
     private static ArmSetpointManager instance;

--- a/src/main/java/frc/robot/input/DualControllerInput.java
+++ b/src/main/java/frc/robot/input/DualControllerInput.java
@@ -87,6 +87,8 @@ public class DualControllerInput extends MoInput {
             return MoInput.ShootTarget.SPEAKER;
         } else if (pov == 180) {
             return MoInput.ShootTarget.AMP;
+        } else if (pov == 90) {
+            return MoInput.ShootTarget.SHUTTLE;
         } else {
             return MoInput.ShootTarget.NONE;
         }

--- a/src/main/java/frc/robot/input/JoystickDualControllerInput.java
+++ b/src/main/java/frc/robot/input/JoystickDualControllerInput.java
@@ -104,6 +104,8 @@ public class JoystickDualControllerInput extends MoInput {
             return MoInput.ShootTarget.SPEAKER;
         } else if (pov == 180) {
             return MoInput.ShootTarget.AMP;
+        } else if (pov == 90) {
+            return MoInput.ShootTarget.SHUTTLE;
         } else {
             return MoInput.ShootTarget.NONE;
         }

--- a/src/main/java/frc/robot/input/MoInput.java
+++ b/src/main/java/frc/robot/input/MoInput.java
@@ -15,6 +15,7 @@ public abstract class MoInput {
     public enum ShootTarget {
         SPEAKER,
         AMP,
+        SHUTTLE,
         NONE
     };
 
@@ -31,6 +32,8 @@ public abstract class MoInput {
             return Optional.of(ArmSetpoint.SPEAKER);
         } else if (shootTarget == ShootTarget.AMP) {
             return Optional.of(ArmSetpoint.AMP);
+        } else if (shootTarget == ShootTarget.SHUTTLE) {
+            return Optional.of(ArmSetpoint.SHUTTLE);
         } else {
             return Optional.empty();
         }

--- a/src/main/java/frc/robot/input/SingleControllerInput.java
+++ b/src/main/java/frc/robot/input/SingleControllerInput.java
@@ -90,6 +90,8 @@ public class SingleControllerInput extends MoInput {
             return MoInput.ShootTarget.SPEAKER;
         } else if (pov == 180) {
             return MoInput.ShootTarget.AMP;
+        } else if (pov == 90) {
+            return MoInput.ShootTarget.SHUTTLE;
         } else {
             return MoInput.ShootTarget.NONE;
         }

--- a/src/main/java/frc/robot/subsystem/ShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystem/ShooterSubsystem.java
@@ -217,7 +217,7 @@ public class ShooterSubsystem extends SubsystemBase {
     }
 
     public void burnFlash() {
-        if(!burnFlashDebounce.hasElapsed(10)) {
+        if (!burnFlashDebounce.hasElapsed(10)) {
             System.out.println("SHOULD NOT BURN FLASH THIS FREQUENLTY");
             return;
         }


### PR DESCRIPTION
Holding X + D-Pad Right (POV 90) will shoot the note horizontally, for rapidly passing pieces to alliance partners on the other side of the field