### PR TITLE
Support for targeting and having multiple Limelights

### DIFF
--- a/src/main/java/frc/robot/command/TeleopDriveCommand.java
+++ b/src/main/java/frc/robot/command/TeleopDriveCommand.java
@@ -83,6 +83,13 @@ public class TeleopDriveCommand extends Command {
             }
             Rotation2d desiredRotation = absoluteZero.plus(Rotation2d.fromRotations(
                     turnRequest * MoPrefs.absoluteRotationRange.get().in(Units.Rotations)));
+
+            drive.driveCartesianPointAt(fwdRequest, leftRequest, foHeading, desiredRotation);
+        } else if (input.getShouldTargetNote()
+                && positioning.frontLimelight.getCrosshair().isPresent()) {
+            var crosshair = positioning.frontLimelight.getCrosshair().get();
+            Rotation2d desiredRotation = foHeading.plus(Rotation2d.fromDegrees(crosshair.getX()));
+
             drive.driveCartesianPointAt(fwdRequest, leftRequest, foHeading, desiredRotation);
         } else {
             drive.driveCartesian(fwdRequest, leftRequest, turnRequest, foHeading);

--- a/src/main/java/frc/robot/command/TeleopDriveCommand.java
+++ b/src/main/java/frc/robot/command/TeleopDriveCommand.java
@@ -10,6 +10,7 @@ import edu.wpi.first.units.Units;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.input.MoInput;
 import frc.robot.subsystem.DriveSubsystem;
+import frc.robot.subsystem.IntakeSubsystem;
 import frc.robot.subsystem.PositioningSubsystem;
 import frc.robot.util.MoPrefs;
 import frc.robot.util.MoPrefs.Pref;
@@ -18,6 +19,7 @@ import java.util.function.Supplier;
 public class TeleopDriveCommand extends Command {
     private final DriveSubsystem drive;
     private final PositioningSubsystem positioning;
+    private final IntakeSubsystem intake;
     private final Supplier<MoInput> inputSupplier;
 
     private Pref<Double> rampTime = MoPrefs.driveRampTime;
@@ -29,9 +31,14 @@ public class TeleopDriveCommand extends Command {
     private boolean saveZero = true;
     private Rotation2d absoluteZero = null;
 
-    public TeleopDriveCommand(DriveSubsystem drive, PositioningSubsystem positioning, Supplier<MoInput> inputSupplier) {
+    public TeleopDriveCommand(
+            DriveSubsystem drive,
+            PositioningSubsystem positioning,
+            IntakeSubsystem intake,
+            Supplier<MoInput> inputSupplier) {
         this.drive = drive;
         this.positioning = positioning;
+        this.intake = intake;
         this.inputSupplier = inputSupplier;
 
         rampTime.subscribe(
@@ -86,6 +93,7 @@ public class TeleopDriveCommand extends Command {
 
             drive.driveCartesianPointAt(fwdRequest, leftRequest, foHeading, desiredRotation);
         } else if (input.getShouldTargetNote()
+                && intake.atDeploySetpoint()
                 && positioning.frontLimelight.getCrosshair().isPresent()) {
             var crosshair = positioning.frontLimelight.getCrosshair().get();
             Rotation2d desiredRotation = foHeading.plus(Rotation2d.fromDegrees(crosshair.getX()));

--- a/src/main/java/frc/robot/component/Limelight.java
+++ b/src/main/java/frc/robot/component/Limelight.java
@@ -38,21 +38,26 @@ public class Limelight {
     private Optional<Pose3d> lastReportedPose = Optional.empty();
     private Optional<Translation2d> lastReportedCrosshair = Optional.empty();
 
-    private final NetworkTable limelightTable =
-            NetworkTableInstance.getDefault().getTable("limelight");
-    private final DoublePublisher pipelinePublisher =
-            limelightTable.getDoubleTopic("pipeline").publish();
-    private final DoublePublisher ledPublisher =
-            limelightTable.getDoubleTopic("ledMode").publish();
-    private final DoubleSubscriber tvSubscriber =
-            limelightTable.getDoubleTopic("tv").subscribe(0);
-    private final DoubleSubscriber txSubscriber =
-            limelightTable.getDoubleTopic("tx").subscribe(0);
-    private final DoubleSubscriber tySubscriber =
-            limelightTable.getDoubleTopic("ty").subscribe(0);
+    private final NetworkTable limelightTable;
+    private final DoublePublisher pipelinePublisher;
+    private final DoublePublisher ledPublisher;
+    private final DoubleSubscriber tvSubscriber;
+    private final DoubleSubscriber txSubscriber;
+    private final DoubleSubscriber tySubscriber;
 
-    private final DoubleArraySubscriber botposeBlueSubscriber =
-            limelightTable.getDoubleArrayTopic("botpose_wpiblue").subscribe(new double[6]);
+    private final DoubleArraySubscriber botposeBlueSubscriber;
+
+    public Limelight(String networkTableName) {
+        limelightTable = NetworkTableInstance.getDefault().getTable(networkTableName);
+        tySubscriber = limelightTable.getDoubleTopic("ty").subscribe(0);
+        txSubscriber = limelightTable.getDoubleTopic("tx").subscribe(0);
+        tvSubscriber = limelightTable.getDoubleTopic("tv").subscribe(0);
+        ledPublisher = limelightTable.getDoubleTopic("ledMode").publish();
+        pipelinePublisher = limelightTable.getDoubleTopic("pipeline").publish();
+
+        botposeBlueSubscriber =
+                limelightTable.getDoubleArrayTopic("botpose_wpiblue").subscribe(new double[6]);
+    }
 
     public Optional<Pose3d> getRobotPose() {
         return lastReportedPose;

--- a/src/main/java/frc/robot/input/DualControllerInput.java
+++ b/src/main/java/frc/robot/input/DualControllerInput.java
@@ -136,4 +136,9 @@ public class DualControllerInput extends MoInput {
     public double getRightClimbRequest() {
         return (armController.getPOV() == 90 ? -1 : 1) * armController.getRightTriggerAxis();
     }
+
+    @Override
+    public boolean getShouldTargetNote() {
+        return false; // Not implemented
+    }
 }

--- a/src/main/java/frc/robot/input/JoystickDualControllerInput.java
+++ b/src/main/java/frc/robot/input/JoystickDualControllerInput.java
@@ -168,4 +168,9 @@ public class JoystickDualControllerInput extends MoInput {
     public double getRightClimbRequest() {
         return (getClimbReverse() ? -1 : 1) * armController.getRightTriggerAxis();
     }
+
+    @Override
+    public boolean getShouldTargetNote() {
+        return joystick.getRawButton(4);
+    }
 }

--- a/src/main/java/frc/robot/input/MoInput.java
+++ b/src/main/java/frc/robot/input/MoInput.java
@@ -69,6 +69,8 @@ public abstract class MoInput {
         return false;
     }
 
+    public abstract boolean getShouldTargetNote();
+
     public abstract boolean getShouldUseSlowSpeed();
 
     public abstract boolean getReZeroGyro();

--- a/src/main/java/frc/robot/input/SingleControllerInput.java
+++ b/src/main/java/frc/robot/input/SingleControllerInput.java
@@ -144,4 +144,9 @@ public class SingleControllerInput extends MoInput {
     public double getRightClimbRequest() {
         return (controller.getPOV() == 90 ? -1 : 1) * controller.getRightTriggerAxis();
     }
+
+    @Override
+    public boolean getShouldTargetNote() {
+        return false; // Not implemented
+    }
 }

--- a/src/main/java/frc/robot/subsystem/ArmSubsystem.java
+++ b/src/main/java/frc/robot/subsystem/ArmSubsystem.java
@@ -96,8 +96,11 @@ public class ArmSubsystem extends SubsystemBase {
 
         shoulderAbsEncoder.setInverted(true);
 
-        var rawWristAbsEncoder = wristMtr.getAbsoluteEncoder(SparkAbsoluteEncoder.Type.kDutyCycle);
-        wristAbsEncoder = MoEncoder.forSparkAbsolute(rawWristAbsEncoder, Units.Rotations);
+        // The absolute encoder for the wrist is plugged into the indexer motor controller, borrow it
+        var indexerMotorController = new CANSparkMax(Constants.SHOOTER_ROLLER_MTR.address(), MotorType.kBrushless);
+        var rawWristBorrowedAbsEncoder =
+                indexerMotorController.getAbsoluteEncoder(SparkAbsoluteEncoder.Type.kDutyCycle);
+        wristAbsEncoder = MoEncoder.forSparkAbsolute(rawWristBorrowedAbsEncoder, Units.Rotations);
 
         wristAbsEncoder.setInverted(false);
 

--- a/src/main/java/frc/robot/subsystem/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystem/DriveSubsystem.java
@@ -10,7 +10,6 @@ import com.momentum4999.motune.PIDTuner;
 import com.revrobotics.CANSparkLowLevel.MotorType;
 import com.revrobotics.CANSparkMax;
 import edu.wpi.first.math.MathUtil;
-import edu.wpi.first.math.filter.LinearFilter;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;

--- a/src/main/java/frc/robot/subsystem/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystem/IntakeSubsystem.java
@@ -19,6 +19,8 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine;
 import frc.robot.Constants;
+import frc.robot.component.IntakeSetpointManager;
+import frc.robot.component.IntakeSetpointManager.IntakeSetpoint;
 import frc.robot.encoder.MoEncoder;
 import frc.robot.util.MoPrefs;
 import frc.robot.util.MoShuffleboard;
@@ -204,5 +206,12 @@ public class IntakeSubsystem extends SubsystemBase {
                                     .angularVelocity(deployEncoder.getVelocity());
                         },
                         this));
+    }
+
+    public boolean atDeploySetpoint() {
+        Measure<Angle> requestedPos = IntakeSetpointManager.getInstance().getSetpoint(IntakeSetpoint.INTAKE);
+        double tolerance = MoPrefs.intakeSetpointVarianceThreshold.get().in(Units.Value);
+
+        return getDeployPosition().isNear(requestedPos, tolerance);
     }
 }

--- a/src/main/java/frc/robot/subsystem/PositioningSubsystem.java
+++ b/src/main/java/frc/robot/subsystem/PositioningSubsystem.java
@@ -30,8 +30,10 @@ public class PositioningSubsystem extends SubsystemBase {
      */
     private static final double POSITION_MAX_ACCEPTABLE_UPDATE_DELTA = 5;
 
-    /** The limelight. Should be used by auto scoring commands for fine targeting. */
-    public final Limelight limelight = new Limelight();
+    /** The limelights. Should be used by auto scoring commands for fine targeting. */
+    public final Limelight rearLimelight = new Limelight("limelightRear");
+
+    public final Limelight frontLimelight = new Limelight("limelightFront");
 
     private Pose2d robotPose = new Pose2d();
 
@@ -135,9 +137,9 @@ public class PositioningSubsystem extends SubsystemBase {
 
     @Override
     public void periodic() {
-        limelight.periodic();
+        rearLimelight.periodic();
 
-        limelight.getRobotPose().ifPresent(pose -> {
+        rearLimelight.getRobotPose().ifPresent(pose -> {
             if (!shouldUseAprilTags.getBoolean(true)) {
                 return;
             }
@@ -151,5 +153,7 @@ public class PositioningSubsystem extends SubsystemBase {
         field.setRobotPose(getRobotPose());
 
         if (fieldOrientedDriveMode.getSelected() != FieldOrientedDriveMode.GYRO) resetFieldOrientedFwd();
+
+        frontLimelight.periodic();
     }
 }

--- a/src/main/java/frc/robot/subsystem/PositioningSubsystem.java
+++ b/src/main/java/frc/robot/subsystem/PositioningSubsystem.java
@@ -31,9 +31,9 @@ public class PositioningSubsystem extends SubsystemBase {
     private static final double POSITION_MAX_ACCEPTABLE_UPDATE_DELTA = 5;
 
     /** The limelights. Should be used by auto scoring commands for fine targeting. */
-    public final Limelight rearLimelight = new Limelight("limelightRear");
+    public final Limelight rearLimelight = new Limelight("limelight");
 
-    public final Limelight frontLimelight = new Limelight("limelightFront");
+    public final Limelight frontLimelight = new Limelight("limelight-front");
 
     private Pose2d robotPose = new Pose2d();
 


### PR DESCRIPTION
- Front and rear limelight
- Allow for "note targeting", which will point the robot towards a crosshair detected by the front limelight while Joystick Button 4 is held